### PR TITLE
slides contribution with xelatex

### DIFF
--- a/0_0_Preamble/Preamble_Fonts_Charter_FiraSans.tex
+++ b/0_0_Preamble/Preamble_Fonts_Charter_FiraSans.tex
@@ -12,6 +12,8 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
+% if we are in xelatex, pass no-math to fontspec to avoid package conflict
+\ifxetex \PassOptionsToPackage{no-math}{fontspec} \fi
 % Use Fira Sans as the sans-serif font.
 % Load first because it otherwise doesn't work properly.
 % ==>

--- a/0_0_Preamble/Preamble_Presentation.tex
+++ b/0_0_Preamble/Preamble_Presentation.tex
@@ -165,7 +165,12 @@
 \usepackage{relsize}
 \renewcommand\RSpercentTolerance{1}
 % Enabling slightly reduced font for CAPS:
-\newcommand{\caps}[1]{\textscale{0.96}{\textls[35]{\MakeUppercase{#1}}}}
+% The command \textls provided by package `microtype' does not work in xelatex.
+\ifxetex
+	\newcommand{\caps}[1]{\textscale{0.96}{\MakeUppercase{#1}}}
+\else
+	\newcommand{\caps}[1]{\textscale{0.96}{\textls[35]{\MakeUppercase{#1}}}}
+\fi
 % <==
 
 
@@ -266,7 +271,7 @@
 }
 \newcommand{\sigstar}{\highlight{*}}
 
-\renewcommand{\alert}[1]{\highlight{\textbf{#1}}}
+\renewcommand{\alert}[1]{\relax\ifmmode\highlight{\textbf{\ensuremath{#1}}}\else\highlight{\textbf{#1}}\fi}
 
 \newlength{\rulelength}
 \setlength{\rulelength}{\paperwidth - \marginleft - \marginright}


### PR DESCRIPTION
Since I have to use the package `ctex`, which is not compatible with `pdflatex`, I switch the compiler to `xelatex`, and fix all the errors occured.

PS I think that it is elegant to use \alert in math mode, so I also modify the code.

- fix slides error when compiled in xelatex
- enable usage of \alert in math mode